### PR TITLE
use `cmake --build` instead of `make`.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                     # clean up cache variables from previous build
                     rm -f CMakeCache.txt
                     cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/.local ..
-                    make all install -j${BUILD_PARALLEL_NUM}
+                    cmake --build . --target install --clean-first -- -j${BUILD_PARALLEL_NUM}
                 '''
             }
         }
@@ -52,7 +52,7 @@ pipeline {
                     mkdir build
                     cd build
                     cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/.local -DCMAKE_PREFIX_PATH=${WORKSPACE}/.local ..
-                    make all -j${BUILD_PARALLEL_NUM}
+                    cmake --build . --target all --clean-first -- -j${BUILD_PARALLEL_NUM}
                 '''
             }
         }
@@ -64,7 +64,7 @@ pipeline {
             steps {
                 sh '''
                     cd build
-                    make test ARGS="--verbose"
+                    ctest --verbose
                 '''
             }
         }
@@ -72,7 +72,7 @@ pipeline {
             steps {
                 sh '''
                     cd build
-                    make doxygen > doxygen.log 2>&1
+                    cmake --build . --target doxygen > doxygen.log 2>&1
                     zip -q -r takatori-doxygen doxygen/html
                 '''
             }

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ cd third_party/fpdecimal
 mkdir -p build
 cd build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release [-DCMAKE_INSTALL_PREFIX=/path/to/install] -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF ..
-ninja
-ninja install
+cmake --build . --target install --clean-first
 ```
 
 ## How to build
@@ -44,7 +43,7 @@ ninja install
 mkdir -p build
 cd build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-ninja
+cmake --build .
 ```
 
 available options:
@@ -59,7 +58,7 @@ available options:
 ### install
 
 ```sh
-ninja install
+cmake --build . --target install
 ```
 
 ### run tests
@@ -71,7 +70,7 @@ ctest
 ### generate documents
 
 ```sh
-ninja doxygen
+cmake --build . --target doxygen
 ```
 
 ## License


### PR DESCRIPTION
This tries to use `cmake --build` (a.k.a. [CMake build tool mode](https://cmake.org/cmake/help/v3.10/manual/cmake.1.html#build-tool-mode)) instead of `make` or `ninja` directly, in `README.md ` and `Jenkinsfile`.