### PR TITLE
Introduce `descriptor::reference`.

### DIFF
--- a/include/takatori/descriptor/element.h
+++ b/include/takatori/descriptor/element.h
@@ -7,6 +7,7 @@
 
 #include "descriptor_kind.h"
 #include "binding_info.h"
+#include "reference.h"
 
 #include <takatori/document/region.h>
 
@@ -24,6 +25,9 @@ class element {
 public:
     /// @brief the entity type.
     using entity_type = binding_info<Kind>;
+
+    /// @brief the light weight reference type.
+    using reference_type = class reference<element<Kind>>;
 
     /// @brief the descriptor kind
     static constexpr inline descriptor_kind tag = Kind;
@@ -63,6 +67,14 @@ public:
     }
 
     /**
+     * @brief returns a light weight reference of this descriptor.
+     * @return a reference
+     */
+    [[nodiscard]] reference_type reference() noexcept {
+        return reference_type { *this };
+    }
+
+    /**
      * @brief returns the document region of this element.
      * @return the document region
      */
@@ -94,6 +106,32 @@ inline bool operator==(element<Kind> const& a, element<Kind> const& b) noexcept 
 }
 
 /**
+ * @brief returns whether or not the each element which the descriptor indicates is same.
+ * @tparam Kind the element kind
+ * @param a the first descriptor
+ * @param b a reference of the second descriptor
+ * @return true if the two descriptors are equivalent
+ * @return false otherwise
+ */
+template<descriptor_kind Kind>
+inline bool operator==(element<Kind> const& a, reference<element<Kind>> b) noexcept {
+    return a.optional_entity() == b.optional_entity();
+}
+
+/**
+ * @brief returns whether or not the each element which the descriptor indicates is same.
+ * @tparam Kind the element kind
+ * @param a a reference of the first descriptor
+ * @param b the second descriptor
+ * @return true if the two descriptors are equivalent
+ * @return false otherwise
+ */
+template<descriptor_kind Kind>
+inline bool operator==(reference<element<Kind>> a, element<Kind> const& b) noexcept {
+    return a.optional_entity() == b.optional_entity();
+}
+
+/**
  * @brief returns whether or not the each element which the descriptor indicates is not same.
  * @tparam Kind the element kind
  * @param a the first descriptor
@@ -103,6 +141,32 @@ inline bool operator==(element<Kind> const& a, element<Kind> const& b) noexcept 
  */
 template<descriptor_kind Kind>
 inline bool operator!=(element<Kind> const& a, element<Kind> const& b) noexcept {
+    return !(a == b);
+}
+
+/**
+ * @brief returns whether or not the each element which the descriptor indicates is not same.
+ * @tparam Kind the element kind
+ * @param a the first descriptor
+ * @param b a reference of the second descriptor
+ * @return true if the two descriptors are different
+ * @return false otherwise
+ */
+template<descriptor_kind Kind>
+inline bool operator!=(element<Kind> const& a, reference<element<Kind>> const& b) noexcept {
+    return !(a == b);
+}
+
+/**
+ * @brief returns whether or not the each element which the descriptor indicates is not same.
+ * @tparam Kind the element kind
+ * @param a a reference of the first descriptor
+ * @param b the second descriptor
+ * @return true if the two descriptors are different
+ * @return false otherwise
+ */
+template<descriptor_kind Kind>
+inline bool operator!=(reference<element<Kind>> const& a, element<Kind> const& b) noexcept {
     return !(a == b);
 }
 

--- a/include/takatori/descriptor/reference.h
+++ b/include/takatori/descriptor/reference.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <ostream>
+#include <utility>
+
+#include "descriptor_kind.h"
+#include "binding_info.h"
+
+#include <takatori/util/hash.h>
+#include <takatori/util/optional_ptr.h>
+
+namespace takatori::descriptor {
+
+/**
+ * @brief a light weight reference of descriptors.
+ * @paragraph This has the same equivalence to the target descriptor,
+ *  that is, each descriptor `u` and `v` satisfies
+ *  `u == v => u == v.reference()`.
+ * @tparam T the descriptor type
+ */
+template<class T>
+class reference {
+public:
+    /// @brief the descriptor type.
+    using descriptor_type = T;
+
+    /// @brief the entity type.
+    using entity_type = typename descriptor_type::entity_type;
+
+    /// @brief the descriptor kind
+    static constexpr inline descriptor_kind tag = descriptor_type::tag;
+
+    /**
+     * @brief creates a new instance which refers an empty descriptor.
+     */
+    constexpr reference() noexcept = default;
+
+    /**
+     * @brief creates a new instance.
+     * @param target the target descriptor
+     */
+    explicit reference(T const& target) noexcept :
+        entity_ { target.optional_entity().get() }
+    {}
+
+    /**
+     * @brief returns the descriptor entity.
+     * @return the descriptor entity
+     * @warning undefined behavior if the entity is absent, or already disposed
+     */
+    [[nodiscard]] constexpr entity_type& entity() const noexcept {
+        return *optional_entity();
+    }
+
+    /**
+     * @brief returns the descriptor entity.
+     * @return the descriptor entity
+     * @return empty if the entity is absent
+     * @warning undefined behavior if the entity is or already disposed
+     */
+    [[nodiscard]] constexpr util::optional_ptr<entity_type> optional_entity() const noexcept {
+        return util::optional_ptr { entity_ };
+    }
+
+private:
+    entity_type* entity_;
+};
+
+/**
+ * @brief returns whether or not the each element which the descriptor indicates is same.
+ * @tparam T the descriptor type
+ * @param a the first descriptor
+ * @param b the second descriptor
+ * @return true if the two descriptors are equivalent
+ * @return false otherwise
+ */
+template<class T>
+inline bool operator==(reference<T> const& a, reference<T> const& b) noexcept {
+    return a.optional_entity() == b.optional_entity();
+}
+
+/**
+ * @brief returns whether or not the each element which the descriptor indicates is not same.
+ * @tparam T the descriptor type
+ * @param a the first descriptor
+ * @param b the second descriptor
+ * @return true if the two descriptors are different
+ * @return false otherwise
+ */
+template<class T>
+inline bool operator!=(reference<T> const& a, reference<T> const& b) noexcept {
+    return !(a == b);
+}
+
+/**
+ * @brief appends string representation of the given value.
+ * @tparam T the descriptor type
+ * @param out the target output
+ * @param value the target value
+ * @return the output stream
+ */
+template<class T>
+inline std::ostream& operator<<(std::ostream& out, reference<T> const& value) {
+    return out << T::tag << "(" << value.optional_entity() << ")";
+}
+
+} // namespace takatori::descriptor
+
+/**
+ * @brief std::hash specialization for takatori::descriptor::reference.
+ * @tparam T the descriptor type
+ */
+template<class T>
+struct std::hash<takatori::descriptor::reference<T>> {
+    /**
+     * @brief compute hash of the given object.
+     * @param value the target object
+     * @return computed hash code
+     */
+    std::size_t operator()(takatori::descriptor::reference<T> const& value) const noexcept {
+        return ::takatori::util::hash(T::tag, value.optional_entity());
+    }
+};

--- a/include/takatori/util/optional_ptr.h
+++ b/include/takatori/util/optional_ptr.h
@@ -21,8 +21,8 @@ class optional_ptr_base {
 public:
     constexpr optional_ptr_base() = default;
     ~optional_ptr_base() = default;
-    optional_ptr_base(optional_ptr_base const&) = delete;
-    optional_ptr_base& operator=(optional_ptr_base const&) = delete;
+    optional_ptr_base(optional_ptr_base const&) noexcept = delete;
+    optional_ptr_base& operator=(optional_ptr_base const&) noexcept = delete;
     constexpr optional_ptr_base(optional_ptr_base&&) noexcept = default;
     constexpr optional_ptr_base& operator=(optional_ptr_base&&) noexcept = default;
 };
@@ -32,8 +32,8 @@ class optional_ptr_base<T, std::enable_if_t<std::is_const_v<T>>> {
 public:
     constexpr optional_ptr_base() = default;
     ~optional_ptr_base() = default;
-    constexpr optional_ptr_base(optional_ptr_base const&) = default;
-    constexpr optional_ptr_base& operator=(optional_ptr_base const&) = default;
+    constexpr optional_ptr_base(optional_ptr_base const&) noexcept = default;
+    constexpr optional_ptr_base& operator=(optional_ptr_base const&) noexcept = default;
     constexpr optional_ptr_base(optional_ptr_base&&) noexcept = default;
     constexpr optional_ptr_base& operator=(optional_ptr_base&&) noexcept = default;
 
@@ -75,7 +75,7 @@ public:
     /**
      * @brief creates a new empty instance.
      */
-    constexpr optional_ptr() = default;
+    constexpr optional_ptr() noexcept = default;
 
     /**
      * @brief destroys this object.
@@ -86,14 +86,14 @@ public:
      * @brief creates a new object.
      * @param other the copy source
      */
-    constexpr optional_ptr(optional_ptr const& other) = default;
+    constexpr optional_ptr(optional_ptr const& other) noexcept = default;
 
     /**
      * @brief assigns the given object.
      * @param other the copy source
      * @return this
      */
-    constexpr optional_ptr& operator=(optional_ptr const& other) = default;
+    constexpr optional_ptr& operator=(optional_ptr const& other) noexcept = default;
 
     /**
      * @brief creates a new object.
@@ -112,9 +112,9 @@ public:
      * @brief creates a new object.
      * @param other the copy source
      */
-    constexpr optional_ptr(optional_ptr& other) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
-        , entry_(other.entry_)
+    constexpr optional_ptr(optional_ptr& other) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {},
+        entry_ { other.entry_ }
     {}
 
     /**
@@ -130,33 +130,33 @@ public:
     /**
      * @brief creates a new empty instance.
      */
-    constexpr optional_ptr(std::nullptr_t) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
+    constexpr optional_ptr(std::nullptr_t) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {}
     {}
 
     /**
      * @brief creates a new empty instance.
      */
-    constexpr optional_ptr(std::nullopt_t) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
+    constexpr optional_ptr(std::nullopt_t) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {}
     {}
 
     /**
      * @brief creates a new instance.
      * @param entry the entry
      */
-    constexpr optional_ptr(reference entry) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
-        , entry_(std::addressof(entry))
+    constexpr optional_ptr(reference entry) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {},
+        entry_ { std::addressof(entry) }
     {}
 
     /**
      * @brief creates a new instance.
      * @param entry the entry
      */
-    explicit constexpr optional_ptr(pointer entry) noexcept
-        : impl::optional_ptr_base<T>()
-        , entry_(entry)
+    explicit constexpr optional_ptr(pointer entry) noexcept :
+        impl::optional_ptr_base<T> {},
+        entry_ { entry }
     {}
 
     /**
@@ -168,9 +168,9 @@ public:
             class U,
             class = std::enable_if_t<std::is_constructible_v<pointer, typename optional_ptr<U>::pointer>>
     >
-    constexpr optional_ptr(optional_ptr<U>& other) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
-        , entry_(other.get())
+    constexpr optional_ptr(optional_ptr<U>& other) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {},
+        entry_ { other.get() }
     {}
 
     /**
@@ -194,11 +194,14 @@ public:
      */
     template<
             class U,
-            class = std::enable_if_t<std::is_constructible_v<pointer, typename optional_ptr<U>::const_pointer>>
+            class = std::enable_if_t<
+                    std::is_constructible_v<
+                            pointer,
+                            typename optional_ptr<U>::const_pointer>>
     >
-    constexpr optional_ptr(optional_ptr<U> const& other) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
-        , entry_(other.get())
+    constexpr optional_ptr(optional_ptr<U> const& other) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {},
+        entry_ { other.get() }
     {}
 
     /**
@@ -208,7 +211,10 @@ public:
      */
     template<
             class U,
-            class = std::enable_if_t<std::is_assignable_v<pointer&, typename optional_ptr<U>::const_pointer>>
+            class = std::enable_if_t<
+                    std::is_assignable_v<
+                            pointer&,
+                            typename optional_ptr<U>::const_pointer>>
     >
     constexpr optional_ptr& operator=(optional_ptr<U> const& other) noexcept {
         entry_ = other.get();
@@ -224,9 +230,9 @@ public:
             class U,
             class = std::enable_if_t<std::is_constructible_v<pointer, typename optional_ptr<U>::pointer>>
     >
-    constexpr optional_ptr(optional_ptr<U>&& other) noexcept // NOLINT
-        : impl::optional_ptr_base<T>()
-        , entry_(other.get())
+    constexpr optional_ptr(optional_ptr<U>&& other) noexcept : // NOLINT
+        impl::optional_ptr_base<T> {},
+        entry_ { other.get() }
     {}
 
     /**
@@ -248,67 +254,101 @@ public:
      * @return true if this reference is empty
      * @return false otherwise
      */
-    [[nodiscard]] constexpr bool empty() const noexcept { return entry_ == nullptr; }
+    [[nodiscard]] constexpr bool empty() const noexcept {
+        return entry_ == nullptr;
+    }
 
     /**
      * @brief returns whether or not this has any entries.
      * @return true if this has entry
      * @return false otherwise
      */
-    [[nodiscard]] constexpr bool has_value() const noexcept { return !empty(); }
+    [[nodiscard]] constexpr bool has_value() const noexcept {
+        return !empty();
+    }
 
     /**
      * @brief returns a pointer to the holding value.
      * @return pointer to the holding value
      * @return nullptr if this reference is empty
      */
-    [[nodiscard]] constexpr pointer get() { return entry_; }
+    [[nodiscard]] constexpr pointer get() {
+        return entry_;
+    }
 
     /// @copydoc get()
-    [[nodiscard]] constexpr const_pointer get() const { return entry_; }
+    [[nodiscard]] constexpr const_pointer get() const {
+        return entry_;
+    }
 
     /**
      * @brief returns the holding value.
      * @return the holding value
      * @throws std::bad_optional_access if this reference is empty
      */
-    constexpr reference value() { check_(); return *entry_; }
+    constexpr reference value() {
+        check_();
+        return *entry_;
+    }
 
     /// @copydoc value()
-    [[nodiscard]] constexpr const_reference value() const { check_(); return *entry_; }
+    [[nodiscard]] constexpr const_reference value() const {
+        check_();
+        return *entry_;
+    }
 
     /**
      * @brief rebinds the holding value.
      * @param entry the new value
      */
-    void reset(std::nullptr_t entry = nullptr) noexcept { entry_ = entry; }
+    void reset(std::nullptr_t entry = nullptr) noexcept {
+        entry_ = entry;
+    }
 
     /// @copydoc reset()
-    void reset(reference entry) noexcept { entry_ = std::addressof(entry); }
+    void reset(reference entry) noexcept {
+        entry_ = std::addressof(entry);
+    }
 
     /// @copydoc reset()
-    void reset(pointer entry) noexcept { entry_ = entry; }
+    void reset(pointer entry) noexcept {
+        entry_ = entry;
+    }
 
     /**
      * @brief swap entries between this and the given object.
      * @param other the target object
      */
-    void swap(optional_ptr& other) noexcept { std::swap(entry_, other.entry_); }
+    void swap(optional_ptr& other) noexcept {
+        std::swap(entry_, other.entry_);
+    }
 
     /// @copydoc has_value()
-    [[nodiscard]] explicit constexpr operator bool() const noexcept { return has_value(); }
+    [[nodiscard]] explicit constexpr operator bool() const noexcept {
+        return has_value();
+    }
 
     /// @copydoc value()
-    constexpr reference operator*() { return value(); }
+    constexpr reference operator*() {
+        return value();
+    }
 
     /// @copydoc value()
-    constexpr const_reference operator*() const { return value(); }
+    constexpr const_reference operator*() const {
+        return value();
+    }
 
     /// @copydoc value()
-    constexpr pointer operator->() { check_(); return entry_; }
+    constexpr pointer operator->() {
+        check_();
+        return entry_;
+    }
 
     /// @copydoc value()
-    constexpr const_pointer operator->() const { check_(); return entry_; }
+    constexpr const_pointer operator->() const {
+        check_();
+        return entry_;
+    }
 
     /**
      * @brief invokes this reference.
@@ -329,26 +369,38 @@ public:
      * @return an iterator that points to the holding value
      * @return end of iteration if this reference is empty
      */
-    [[nodiscard]] iterator begin() noexcept { return entry_ == nullptr ? nullptr : entry_; }
+    [[nodiscard]] iterator begin() noexcept {
+        return entry_ == nullptr ? nullptr : entry_;
+    }
 
     /// @copydoc begin()
-    [[nodiscard]] const_iterator begin() const noexcept { return cbegin(); }
+    [[nodiscard]] const_iterator begin() const noexcept {
+        return cbegin();
+    }
 
     /// @copydoc begin()
-    [[nodiscard]] const_iterator cbegin() const noexcept { return entry_ == nullptr ? nullptr : entry_; }
+    [[nodiscard]] const_iterator cbegin() const noexcept {
+        return entry_ == nullptr ? nullptr : entry_;
+    }
 
     /**
      * @brief returns a sentinel of the iterator.
      * @return a sentinel of the iterator
      * @see begin()
      */
-    [[nodiscard]] iterator end() noexcept { return entry_ == nullptr ? nullptr : entry_ + 1; }  // NOLINT
+    [[nodiscard]] iterator end() noexcept { // NOLINT
+        return entry_ == nullptr ? nullptr : entry_ + 1;
+    }
 
     /// @copydoc end()
-    [[nodiscard]] const_iterator end() const noexcept { return cend(); }  // NOLINT
+    [[nodiscard]] const_iterator end() const noexcept { // NOLINT
+        return cend();
+    }
 
     /// @copydoc end()
-    [[nodiscard]] const_iterator cend() const noexcept { return entry_ == nullptr ? nullptr : entry_ + 1; }  // NOLINT
+    [[nodiscard]] const_iterator cend() const noexcept { // NOLINT
+        return entry_ == nullptr ? nullptr : entry_ + 1;
+    }
 
 private:
     pointer entry_ {};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,10 @@ add_test_executable(takatori/datetime/datetime_interval_test.cpp)
 add_test_executable(takatori/datetime/time_point_test.cpp)
 add_test_executable(takatori/datetime/time_zone_test.cpp)
 
+# descriptors
+add_test_executable(takatori/descriptor/descriptor_element_test.cpp)
+add_test_executable(takatori/descriptor/descriptor_reference_test.cpp)
+
 # scalar expression models
 add_test_executable(takatori/scalar/immediate_test.cpp)
 add_test_executable(takatori/scalar/variable_reference_test.cpp)

--- a/test/takatori/descriptor/descriptor_element_test.cpp
+++ b/test/takatori/descriptor/descriptor_element_test.cpp
@@ -1,0 +1,69 @@
+#include <takatori/descriptor/element.h>
+
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include <takatori/descriptor/variable.h>
+#include <takatori/testing/descriptors.h>
+
+namespace takatori::descriptor {
+
+class descriptor_element_test : public ::testing::Test {};
+
+using takatori::testing::mock_binding_info;
+using info = mock_binding_info<variable::tag, int>;
+using takatori::testing::value_of;
+
+TEST_F(descriptor_element_test, simple) {
+    variable d { std::make_shared<info>(1) };
+    EXPECT_EQ(decltype(d)::tag, variable::tag);
+    EXPECT_EQ(value_of<int>(d), 1);
+}
+
+TEST_F(descriptor_element_test, optional_entity) {
+    variable d { std::make_shared<info>(1) };
+    EXPECT_EQ(d.optional_entity().get(), std::addressof(d.entity()));
+}
+
+TEST_F(descriptor_element_test, optional_entity_empty) {
+    variable e { std::shared_ptr<info> {} };
+    EXPECT_FALSE(e.optional_entity());
+}
+
+TEST_F(descriptor_element_test, shared_entity) {
+    variable d { std::make_shared<info>(1) };
+    EXPECT_EQ(d.shared_entity().get(), std::addressof(d.entity()));
+}
+
+TEST_F(descriptor_element_test, eq) {
+    variable a { std::make_shared<info>(1) };
+    variable b { std::make_shared<info>(1) };
+    variable c { std::make_shared<info>(2) };
+    variable e { std::shared_ptr<info> {} };
+    variable f { std::shared_ptr<info> {} };
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, c);
+    EXPECT_NE(a, e);
+    EXPECT_EQ(e, f);
+}
+
+TEST_F(descriptor_element_test, hash) {
+    std::hash<variable> h {};
+    variable a { std::make_shared<info>(1) };
+    variable b { std::make_shared<info>(1) };
+    variable c { std::make_shared<info>(2) };
+    variable e { std::shared_ptr<info> {} };
+    variable f { std::shared_ptr<info> {} };
+    EXPECT_EQ(h(a), h(b));
+    EXPECT_NE(h(a), h(c));
+    EXPECT_NE(h(a), h(e));
+    EXPECT_EQ(h(e), h(f));
+}
+
+TEST_F(descriptor_element_test, output) {
+    variable d { std::make_shared<info>(1) };
+    std::cout << d << std::endl;
+}
+
+} // namespace takatori::descriptor

--- a/test/takatori/descriptor/descriptor_reference_test.cpp
+++ b/test/takatori/descriptor/descriptor_reference_test.cpp
@@ -1,0 +1,77 @@
+#include <takatori/descriptor/reference.h>
+
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include <takatori/descriptor/element.h>
+#include <takatori/descriptor/variable.h>
+#include <takatori/testing/mock_binding_info.h>
+
+namespace takatori::descriptor {
+
+class descriptor_reference_test : public ::testing::Test {};
+
+using takatori::testing::mock_binding_info;
+using info = mock_binding_info<variable::tag, int>;
+
+static_assert(std::is_trivially_copyable_v<variable::reference_type>);
+static_assert(std::is_same_v<variable::reference_type::descriptor_type, variable>);
+static_assert(variable::reference_type::tag == variable::tag);
+
+TEST_F(descriptor_reference_test, simple) {
+    variable d { std::make_shared<info>(1) };
+    auto r = d.reference();
+    EXPECT_EQ(decltype(r)::tag, variable::tag);
+    EXPECT_EQ(r, d);
+}
+
+TEST_F(descriptor_reference_test, eq) {
+    variable a { std::make_shared<info>(1) };
+    variable b { std::make_shared<info>(1) };
+    variable c { std::make_shared<info>(2) };
+    variable e { std::shared_ptr<info> {} };
+    variable f { std::shared_ptr<info> {} };
+
+    EXPECT_EQ(a.reference(), b.reference());
+    EXPECT_NE(a.reference(), c.reference());
+    EXPECT_NE(a.reference(), e.reference());
+    EXPECT_EQ(e.reference(), f.reference());
+
+    EXPECT_EQ(a, b.reference());
+    EXPECT_NE(a, c.reference());
+    EXPECT_NE(a, e.reference());
+    EXPECT_EQ(e, f.reference());
+
+    EXPECT_EQ(a.reference(), b);
+    EXPECT_NE(a.reference(), c);
+    EXPECT_NE(a.reference(), e);
+    EXPECT_EQ(e.reference(), f);
+}
+
+TEST_F(descriptor_reference_test, hash) {
+    std::hash<variable> hd {};
+    std::hash<reference<variable>> hr {};
+    variable a { std::make_shared<info>(1) };
+    variable b { std::make_shared<info>(1) };
+    variable c { std::make_shared<info>(2) };
+    variable e { std::shared_ptr<info> {} };
+    variable f { std::shared_ptr<info> {} };
+
+    EXPECT_EQ(hr(a.reference()), hr(b.reference()));
+    EXPECT_NE(hr(a.reference()), hr(c.reference()));
+    EXPECT_NE(hr(a.reference()), hr(e.reference()));
+    EXPECT_EQ(hr(e.reference()), hr(f.reference()));
+
+    EXPECT_EQ(hd(a), hr(b.reference()));
+    EXPECT_NE(hd(a), hr(c.reference()));
+    EXPECT_NE(hd(a), hr(e.reference()));
+    EXPECT_EQ(hd(e), hr(f.reference()));
+}
+
+TEST_F(descriptor_reference_test, output) {
+    variable d { std::make_shared<info>(1) };
+    std::cout << d.reference() << std::endl;
+}
+
+} // namespace takatori::descriptor


### PR DESCRIPTION
Each descriptor object now provides `it.reference()`.
It is a light weight reference of the original descriptor,
that can compare like as `d == d.reference()`.