### PR TITLE
stop using "TRUE" (for FTBFS with ICU-68)

### DIFF
--- a/src/takatori/datetime/time_zone_impl.cpp
+++ b/src/takatori/datetime/time_zone_impl.cpp
@@ -19,7 +19,7 @@ time_zone::impl::impl(std::string name, std::unique_ptr<entity_type> entity)
     entity_->getID(lid);
     UErrorCode status {};
     entity_type::getCanonicalID(lid, cid, status);
-    if (U_SUCCESS(status) == TRUE) {
+    if (U_SUCCESS(status)) { // NOLINT
         cid.toUTF8String(id_);
     } else {
         lid.toUTF8String(id_);


### PR DESCRIPTION
ICU-68 で `TRUE` が廃止されコンパイルエラーとなるため、その修正です。
See: https://icu.unicode.org/download/68#h.ttu18jpjexm1

(Ubuntu 22.04 LTS では ICU 70.1 を採用しています)