### PR TITLE
add missing include (for FTBFS with gcc-13)

### DIFF
--- a/include/takatori/serializer/value_input_exception.h
+++ b/include/takatori/serializer/value_input_exception.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace takatori::serializer {


### PR DESCRIPTION
`<cstdint>` の include が足りていない箇所があり g++-13 でコンパイルエラーになる問題の修正です。
参考: https://gcc.gnu.org/gcc-13/porting_to.html
