### PR TITLE
fix for FTBFS with gcc-13 (test code)

### DIFF
--- a/include/takatori/datetime/interval.h
+++ b/include/takatori/datetime/interval.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "date_interval.h"
 #include "time_interval.h"
 #include "datetime_interval.h"

--- a/include/takatori/graph/multiport.h
+++ b/include/takatori/graph/multiport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <utility>
 
 #include <boost/container/small_vector.hpp>

--- a/include/takatori/serializer/json_printer.h
+++ b/include/takatori/serializer/json_printer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <ostream>
 

--- a/include/takatori/value/date.h
+++ b/include/takatori/value/date.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 
 #include "value_kind.h"

--- a/include/takatori/value/datetime_interval.h
+++ b/include/takatori/value/datetime_interval.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 
 #include "value_kind.h"

--- a/include/takatori/value/time_of_day.h
+++ b/include/takatori/value/time_of_day.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 
 #include "value_kind.h"

--- a/include/takatori/value/time_point.h
+++ b/include/takatori/value/time_point.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <ostream>
 
 #include "value_kind.h"

--- a/test/takatori/util/optional_ptr_test.cpp
+++ b/test/takatori/util/optional_ptr_test.cpp
@@ -93,7 +93,7 @@ TEST_F(optional_reference_test, empty) {
     optional_ptr<std::string> ref;
     ASSERT_FALSE(ref);
     EXPECT_THROW(*ref, std::bad_optional_access);
-    EXPECT_THROW(ref->data(), std::bad_optional_access);
+    EXPECT_THROW((void) ref->data(), std::bad_optional_access);
     EXPECT_EQ(ref.begin(), ref.end());
 }
 
@@ -102,7 +102,7 @@ TEST_F(optional_reference_test, nullptr) {
     optional_ptr<std::string> ref {ptr };
     ASSERT_FALSE(ref);
     EXPECT_THROW(*ref, std::bad_optional_access);
-    EXPECT_THROW(ref->data(), std::bad_optional_access);
+    EXPECT_THROW((void) ref->data(), std::bad_optional_access);
     EXPECT_EQ(ref.begin(), ref.end());
 }
 


### PR DESCRIPTION
#35 で `<cstdint>` の include が足りていない箇所の修正をしましたが、テストコードから使われている部分が未解消だったため、それを含めて網羅的に修正しました。
それに加えて、テストコード中の例外発生を確認するコードで `std::string::data()` を呼び出しているものがありますが、GCC 13 の libstdc++ からはいろいろなメソッドに `[[nodiscard]]` がつくようになったため、これがコンパイル時警告 (`-Werro` でエラー) になる問題の修正です。