### PR TITLE
fall back to Boost::stacktrace_basic if Boost::stacktrace_backtrace is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,18 @@ find_package(ICU 60
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(boost_stacktrace_component stacktrace_backtrace)
 find_package(Boost 1.65
     COMPONENTS container
-    COMPONENTS ${boost_stacktrace_component}
+    OPTIONAL_COMPONENTS stacktrace_backtrace stacktrace_basic
     REQUIRED)
+if(Boost_STACKTRACE_BACKTRACE_FOUND
+   AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    set(boost_stacktrace_component stacktrace_backtrace)
+elseif(Boost_STACKTRACE_BASIC_FOUND)
+    set(boost_stacktrace_component stacktrace_basic)
+else()
+    message(FATAL_ERROR "No usable Boost stacktrace component")
+endif()
 
 find_package(Doxygen
     OPTIONAL_COMPONENTS dot)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,10 @@ find_package(ICU 60
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
+set(boost_stacktrace_component stacktrace_backtrace)
 find_package(Boost 1.65
     COMPONENTS container
-    COMPONENTS stacktrace_backtrace
+    COMPONENTS ${boost_stacktrace_component}
     REQUIRED)
 
 find_package(Doxygen

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,1 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.65 COMPONENTS @boost_stacktrace_component@ REQUIRED)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@package_name@-targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -245,7 +245,7 @@ target_compile_definitions(takatori
     PUBLIC BOOST_ENABLE_ASSERT_DEBUG_HANDLER
 )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (boost_stacktrace_component STREQUAL "stacktrace_backtrace")
     target_link_libraries(takatori
         PUBLIC Boost::stacktrace_backtrace
         PUBLIC ${CMAKE_DL_LIBS}
@@ -254,9 +254,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         PUBLIC BOOST_STACKTRACE_USE_BACKTRACE
     )
 else()
-    # FIXME: more compilers
     target_link_libraries(takatori
-        PUBLIC Boost::stacktrace_noop
+        PUBLIC Boost::stacktrace_basic
+        PUBLIC ${CMAKE_DL_LIBS}
     )
 endif()
 


### PR DESCRIPTION
Debian/Ubuntu 以外の環境 (FreeBSD や RedHat 系 Linux ディストリビューション) では、
標準提供されているパッケージでは Boost::stacktrace_backtrace が使えないことが多いため、
使えない環境では Boost::stacktrace_basic を使うようにする変更です。

また、 takatori を使用するモジュールが、自身の CMakeLists.txt で (takatori が依存している) Boost;;stacktrace_backtrace への依存を明示的に指定しないとビルドが通らない状態だったので、 takatori が export する Config ファイルに、 takatori が選択した Boost::stacktrace のライブラリへの依存を指定するように修正しました。

もともとは、コンパイラに G++ 以外を使用する場合に Boost::stacktrace_noop を使うようにされていましたが、
https://www.boost.org/doc/libs/1_65_0/doc/html/stacktrace/configuration_and_build.html によれば

* Clang でも stacktrace_backtrace が使える
* stacktrace_basic はデフォルトで使える

とのことですので、

* Clang++ の場合にも stacktrace_backtrace を使うように
* 他の理由で使えない場合のフォールバック先は stacktrace_noop でなく stacktrace_basic に

変更しました。

