### PR TITLE
ci: change Analysis job env to almalinux/clang

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: "-*,\
 abseil-*,\
 boost-*,\
+-boost-use-ranges,\
 bugprone-*,\
 -bugprone-branch-clone,\
 -bugprone-easily-swappable-parameters,\
@@ -48,6 +49,7 @@ readability-*,\
 -readability-braces-around-statements,\
 -readability-identifier-length,\
 -readability-convert-member-functions-to-static,\
+-readability-math-missing-parentheses,\
 -readability-named-parameter,\
 -readability-magic-numbers,\
 -readability-redundant-inline-specifier,\

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,10 +60,15 @@ jobs:
       checks: write
     timeout-minutes: 30
     container:
-      image: ghcr.io/project-tsurugi/tsurugi-ci:ubuntu-22.04
+      image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
     defaults:
       run:
         shell: bash
+    env:
+      CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
+      CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+      CC: clang
+      CXX: clang++
 
     steps:
       - name: Checkout
@@ -71,15 +76,16 @@ jobs:
         with:
           submodules: true
 
-      - name: CMake_Generate
+      - name: CMake_Build
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_STRICT=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
+          cmake --build . --target all --clean-first
 
       - name: Clang-Tidy
         run: |
-          python tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' -exclude='(parser|scanner)\.cpp$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' -exclude='(parser|scanner)\.cpp$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       - name: Doxygen
         run: |

--- a/include/takatori/graph/graph.h
+++ b/include/takatori/graph/graph.h
@@ -199,7 +199,7 @@ public:
     template<
             class U,
             class = std::enable_if_t<
-                    std::is_convertible_v<U, const_reference>>>
+                    std::is_convertible_v<U, const_reference>>> // NOLINT(modernize-type-traits)
     U& insert(U&& element) {
         static_assert(util::is_clonable_v<element_type>);
         auto* entry = insert_element(util::clone_unique(std::forward<U>(element)));

--- a/include/takatori/name/identifier.h
+++ b/include/takatori/name/identifier.h
@@ -36,7 +36,7 @@ public:
      */
     template<
             class StringViewLike,
-            class = std::enable_if_t<std::is_constructible_v<token_type, StringViewLike>, StringViewLike>>
+            class = std::enable_if_t<std::is_constructible_v<token_type, StringViewLike>, StringViewLike>> // NOLINT(*-avoid-c-arrays)
     identifier(StringViewLike const& token) : // NOLINT
         token_ { token }
     {}

--- a/include/takatori/util/reference_vector.h
+++ b/include/takatori/util/reference_vector.h
@@ -162,7 +162,7 @@ public:
      */
     template<
             class U,
-            class = std::enable_if_t<std::is_convertible_v<typename std::initializer_list<U>::reference, const_reference>>>
+            class = std::enable_if_t<std::is_convertible_v<typename std::initializer_list<U>::reference, const_reference>>> // NOLINT(modernize-type-traits)
     reference_vector(std::initializer_list<U> list)
     {
         assign(list);

--- a/src/takatori/datetime/time_zone.cpp
+++ b/src/takatori/datetime/time_zone.cpp
@@ -33,7 +33,7 @@ static std::shared_ptr<time_zone::impl> from_offset(std::chrono::minutes offset,
                   static_cast<int>(minute_part.count()));
 
     std::unique_ptr<impl::entity_type> entity { impl::entity_type::createTimeZone(buffer.data()) };
-    if (*entity == impl::entity_type::getUnknown()) {
+    if (*entity == impl::entity_type::getUnknown()) { // NOLINT(readability-implicit-bool-conversion) -- for ICU <= 69
         return {};
     }
     return std::make_shared<impl>(buffer.data(), std::move(entity));
@@ -51,7 +51,7 @@ static std::shared_ptr<time_zone::impl> from_symbol(std::string_view symbol, boo
     }
     icu::UnicodeString string { symbol.data(), static_cast<std::int32_t>(symbol.size()) };
     std::unique_ptr<impl::entity_type> entity { impl::entity_type::createTimeZone(string) };
-    if (*entity == impl::entity_type::getUnknown()) {
+    if (*entity == impl::entity_type::getUnknown()) { // NOLINT(readability-implicit-bool-conversion) -- for ICU <= 69
         if (or_throw) throw_exception(std::invalid_argument(std::string("unknown time zone symbol: ") += symbol));
         return {};
     }

--- a/src/takatori/plan/graph.cpp
+++ b/src/takatori/plan/graph.cpp
@@ -19,7 +19,7 @@ using ::takatori::util::clone_unique;
 using ::takatori::util::unsafe_downcast;
 
 template<class T, class Mapping>
-void repair_upstreams(Mapping const& mapping, step const& from, step& to) {
+static void repair_upstreams(Mapping const& mapping, step const& from, step& to) {
     BOOST_ASSERT(from.kind() == to.kind()); // NOLINT
     auto&& from_t = unsafe_downcast<T>(from);
     auto&& to_t = unsafe_downcast<T>(to);

--- a/src/takatori/serializer/details/simple_value_scanner.cpp
+++ b/src/takatori/serializer/details/simple_value_scanner.cpp
@@ -39,7 +39,7 @@ void simple_value_scanner::operator()(value::character const& element) {
 }
 
 void simple_value_scanner::operator()(value::octet const& element) {
-    thread_local std::string buffer {};
+    thread_local std::string buffer {}; // NOLINT(misc-use-internal-linkage)
     static constexpr std::array<char, 16> hex {
             '0', '1', '2', '3',
             '4', '5', '6', '7',

--- a/src/takatori/serializer/value_input.cpp
+++ b/src/takatori/serializer/value_input.cpp
@@ -227,7 +227,7 @@ double read_float8(buffer_view::const_iterator& position, buffer_view::const_ite
     return result;
 }
 
-const_buffer_view read_decimal_coefficient(buffer_view::const_iterator& position, buffer_view::const_iterator end) {
+static const_buffer_view read_decimal_coefficient(buffer_view::const_iterator& position, buffer_view::const_iterator end) {
     auto size = read_uint(position, end);
     if (size == 0 || size > max_decimal_coefficient_size) {
         throw_decimal_coefficient_out_of_range(size);

--- a/src/takatori/serializer/value_output.cpp
+++ b/src/takatori/serializer/value_output.cpp
@@ -368,7 +368,7 @@ bool write_bit(
     if (number_of_bits > blocks.size() * 8) {
         throw_exception(std::out_of_range("too large number of bits"));
     }
-    util::const_bitset_view bits { blocks.data(), number_of_bits };
+    util::const_bitset_view bits { blocks.data(), number_of_bits }; // NOLINT(bugprone-suspicious-stringview-data-usage)
     BOOST_ASSERT(bits.block_size() <= blocks.size()); // NOLINT
     return write_bit(bits, position, end);
 }

--- a/src/takatori/value/bit.cpp
+++ b/src/takatori/value/bit.cpp
@@ -19,7 +19,7 @@ bit::bit(std::string_view bits) {
         } else if (c == '1') {
             entity_.push_back(true);
         } else {
-            throw_exception(std::invalid_argument(bits.data()));
+            throw_exception(std::invalid_argument(std::string { bits }));
         }
     }
 }


### PR DESCRIPTION
CI environment changes to enable build compatibility verification with Clang on AlmaLinux and static analysis with new version of Clang-Tidy on Analysis job.